### PR TITLE
Add FastAPI backend boilerplate

### DIFF
--- a/my_superset_fastapi/.env.example
+++ b/my_superset_fastapi/.env.example
@@ -1,0 +1,8 @@
+APP_NAME=My Superset FastAPI
+DEBUG=True
+SECRET_KEY=replace-this
+DATABASE_URL=postgresql+asyncpg://superset:superset@localhost:5432/superset
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/1
+ALLOWED_ORIGINS=http://localhost:8088
+RATE_LIMIT=100/minute

--- a/my_superset_fastapi/Dockerfile
+++ b/my_superset_fastapi/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /code
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/my_superset_fastapi/README.md
+++ b/my_superset_fastapi/README.md
@@ -1,0 +1,54 @@
+# My Superset FastAPI
+
+A modular FastAPI backend inspired by Apache Superset with a lightweight Next.js frontend.
+
+## Development
+
+### Backend
+
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the API
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+### Frontend
+
+1. Change to the frontend folder
+   ```bash
+   cd ../my_superset_frontend
+   npm install
+   ```
+2. Copy `.env.local.example` to `.env.local` and adjust `NEXT_PUBLIC_API_URL` if needed
+3. Start Next.js
+   ```bash
+   npm run dev
+   ```
+
+### Docker Compose
+
+From the `my_superset_fastapi` folder run:
+
+```bash
+docker-compose up --build
+```
+
+This starts Postgres, Redis, the FastAPI API, Celery worker, and the Next.js frontend at `http://localhost:3000`.
+
+The application expects environment variables defined in `.env` (see `.env.example`).
+
+### Testing API calls
+
+Use the frontend pages or interact with the API directly, for example:
+
+```bash
+curl http://localhost:8000/api/v1/datasets
+```
+
+### Troubleshooting
+
+- **CORS or 401 errors**: ensure the backend URL in `.env.local` matches the running API and that the API is running.
+- **Containers fail to start**: try `docker-compose build --no-cache`.

--- a/my_superset_fastapi/alembic.ini
+++ b/my_superset_fastapi/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = alembic
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/my_superset_fastapi/alembic/env.py
+++ b/my_superset_fastapi/alembic/env.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context  # type: ignore[attr-defined]
+from app.core.config import get_settings
+from app.models import base
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+fileConfig(config.config_file_name)
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+
+TargetMetadata = base.Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=settings.DATABASE_URL, target_metadata=TargetMetadata, literal_binds=True
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=TargetMetadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/my_superset_fastapi/app/api/__init__.py
+++ b/my_superset_fastapi/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API router modules."""

--- a/my_superset_fastapi/app/api/v1/__init__.py
+++ b/my_superset_fastapi/app/api/v1/__init__.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from . import charts, dashboards, databases, datasets, queries
+
+api_router = APIRouter()
+api_router.include_router(datasets.router)
+api_router.include_router(charts.router)
+api_router.include_router(dashboards.router)
+api_router.include_router(databases.router)
+api_router.include_router(queries.router)

--- a/my_superset_fastapi/app/api/v1/charts.py
+++ b/my_superset_fastapi/app/api/v1/charts.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.schemas.chart import ChartCreate, ChartRead
+from app.services.chart_service import ChartService
+
+router = APIRouter(prefix="/charts", tags=["charts"])
+db_dep = Depends(get_db)
+
+
+@router.post("/", response_model=ChartRead, status_code=status.HTTP_201_CREATED)
+async def create_chart(data: ChartCreate, db: AsyncSession = db_dep) -> ChartRead:
+    return await ChartService.create(db, data)
+
+
+@router.get("/preview/{chart_id}", response_model=ChartRead)
+async def preview_chart(chart_id: int, db: AsyncSession = db_dep) -> ChartRead:
+    # TODO: return sample data for frontend preview
+    chart = await ChartService.get(db, chart_id)
+    if not chart:
+        raise HTTPException(status_code=404, detail="Chart not found")
+    return chart
+
+
+@router.get("/", response_model=list[ChartRead])
+async def list_charts(db: AsyncSession = db_dep) -> list[ChartRead]:
+    return await ChartService.list(db)

--- a/my_superset_fastapi/app/api/v1/dashboards.py
+++ b/my_superset_fastapi/app/api/v1/dashboards.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.schemas.dashboard import DashboardCreate, DashboardRead
+from app.services.dashboard_service import DashboardService
+
+router = APIRouter(prefix="/dashboards", tags=["dashboards"])
+db_dep = Depends(get_db)
+
+
+@router.post("/", response_model=DashboardRead, status_code=status.HTTP_201_CREATED)
+async def create_dashboard(
+    data: DashboardCreate, db: AsyncSession = db_dep
+) -> DashboardRead:
+    return await DashboardService.create(db, data)
+
+
+@router.get("/", response_model=list[DashboardRead])
+async def list_dashboards(db: AsyncSession = db_dep) -> list[DashboardRead]:
+    return await DashboardService.list(db)
+
+
+@router.get("/preview/{dashboard_id}", response_model=DashboardRead)
+async def preview_dashboard(
+    dashboard_id: int, db: AsyncSession = db_dep
+) -> DashboardRead:
+    # TODO: return layout with chart data for preview
+    dashboard = await DashboardService.get(db, dashboard_id)
+    if not dashboard:
+        raise HTTPException(status_code=404, detail="Dashboard not found")
+    return dashboard

--- a/my_superset_fastapi/app/api/v1/databases.py
+++ b/my_superset_fastapi/app/api/v1/databases.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.schemas.database import DatabaseCreate, DatabaseRead
+from app.services.database_service import DatabaseService
+
+router = APIRouter(prefix="/databases", tags=["databases"])
+
+
+@router.post("/", response_model=DatabaseRead, status_code=status.HTTP_201_CREATED)
+async def create_database(
+    data: DatabaseCreate,
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> DatabaseRead:
+    return await DatabaseService.create(db, data)
+
+
+@router.post("/test", status_code=status.HTTP_200_OK)
+async def test_connection(
+    data: DatabaseCreate,
+    db: AsyncSession = Depends(get_db),  # noqa: B008,PT028
+) -> dict[str, str]:
+    await DatabaseService.test_connection(data)
+    return {"status": "ok"}
+
+
+@router.get("/{database_id}/schema", status_code=status.HTTP_200_OK)
+async def get_schema(
+    database_id: int,
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> dict[str, list[str]]:
+    return await DatabaseService.introspect_schema(db, database_id)

--- a/my_superset_fastapi/app/api/v1/datasets.py
+++ b/my_superset_fastapi/app/api/v1/datasets.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.schemas.dataset import DatasetCreate, DatasetRead
+from app.services.dataset_service import DatasetService
+
+router = APIRouter(prefix="/datasets", tags=["datasets"])
+
+
+@router.post("/", response_model=DatasetRead, status_code=status.HTTP_201_CREATED)
+async def create_dataset(
+    data: DatasetCreate,
+    db: AsyncSession = Depends(get_db),  # noqa: B008
+) -> DatasetRead:
+    # TODO: enforce role-based auth once auth setup is stable
+    return await DatasetService.create(db, data)
+
+
+@router.get("/", response_model=list[DatasetRead])
+async def list_datasets(db: AsyncSession = Depends(get_db)) -> list[DatasetRead]:  # noqa: B008
+    return await DatasetService.list(db)

--- a/my_superset_fastapi/app/api/v1/queries.py
+++ b/my_superset_fastapi/app/api/v1/queries.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.schemas.query import QueryCreate, QueryRead
+from app.services.query_service import QueryService
+
+router = APIRouter(prefix="/queries", tags=["queries"])
+
+db_dep = Depends(get_db)
+
+
+@router.post("/", response_model=QueryRead, status_code=status.HTTP_202_ACCEPTED)
+async def submit_query(data: QueryCreate, db: AsyncSession = db_dep) -> QueryRead:
+    result = await QueryService.submit_query(db, data.sql, data.database_id)
+    return result
+
+
+@router.get("/{query_id}", response_model=QueryRead)
+async def get_query(query_id: int, db: AsyncSession = db_dep) -> QueryRead:
+    result = await QueryService.get_result(db, query_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Query not found")
+    return result

--- a/my_superset_fastapi/app/auth/__init__.py
+++ b/my_superset_fastapi/app/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication and authorization utilities."""

--- a/my_superset_fastapi/app/auth/manager.py
+++ b/my_superset_fastapi/app/auth/manager.py
@@ -1,0 +1,43 @@
+from fastapi_users import BaseUserManager, FastAPIUsers
+from fastapi_users.authentication import AuthenticationBackend, CookieTransport
+from fastapi_users.authentication.strategy.jwt import JWTStrategy
+from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
+
+from app.core.config import get_settings
+from app.core.db import AsyncSessionLocal
+
+from .models import User
+
+settings = get_settings()
+
+cookie_transport = CookieTransport(cookie_name="auth", cookie_max_age=3600)
+
+# NOTE: For simplicity we use cookie auth with OAuth2; customize as needed
+
+
+class UserManager(BaseUserManager[User, int]):
+    reset_password_token_secret = settings.SECRET_KEY
+    verification_token_secret = settings.SECRET_KEY
+
+
+async def get_user_db() -> SQLAlchemyUserDatabase:
+    async with AsyncSessionLocal() as session:
+        yield SQLAlchemyUserDatabase(session, User)
+
+
+def get_jwt_strategy() -> JWTStrategy:
+    return JWTStrategy(secret=settings.SECRET_KEY, lifetime_seconds=3600)
+
+
+backend = AuthenticationBackend(
+    name="cookie",
+    transport=cookie_transport,
+    get_strategy=get_jwt_strategy,
+)
+
+fastapi_users = FastAPIUsers[User, int](
+    get_user_manager=UserManager,
+    auth_backends=[backend],
+)
+
+current_active_user = fastapi_users.current_user()

--- a/my_superset_fastapi/app/auth/models.py
+++ b/my_superset_fastapi/app/auth/models.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+from fastapi_users_db_sqlalchemy import SQLAlchemyBaseUserTable
+from sqlalchemy import Column, Enum as SqlEnum, Integer
+
+from app.models.base import Base
+
+
+class Role(str, Enum):
+    ADMIN = "admin"
+    ANALYST = "analyst"
+    VIEWER = "viewer"
+
+
+class User(SQLAlchemyBaseUserTable[int], Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    role = Column(SqlEnum(Role), nullable=False, default=Role.VIEWER)
+
+    # Additional user fields can be added here

--- a/my_superset_fastapi/app/core/celery.py
+++ b/my_superset_fastapi/app/core/celery.py
@@ -1,0 +1,48 @@
+from celery import Celery
+
+from .config import get_settings
+
+settings = get_settings()
+
+celery_app = Celery("my_superset_fastapi", broker=settings.CELERY_BROKER_URL)
+celery_app.conf.update(result_backend=settings.CELERY_RESULT_BACKEND)
+
+
+@celery_app.task
+def health_check() -> str:
+    return "ok"
+
+
+@celery_app.task(name="execute_sql")
+def execute_sql(query_id: int) -> None:
+    """Execute SQL in the background and store result."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from app.core.db import AsyncSessionLocal
+    from app.models import Database, QueryResult
+
+    async def _run() -> None:
+        async with AsyncSessionLocal() as session:
+            result = await session.get(QueryResult, query_id)
+            if not result:
+                return
+            db = await session.get(Database, result.database_id)
+            engine = create_async_engine(db.sqlalchemy_uri)
+            try:
+                async with engine.connect() as conn:
+                    res = await conn.execute(text(result.sql))
+                    rows = res.fetchall()
+                    result.result = str(rows)
+                    result.rows = len(rows)
+                    result.status = "success"
+            except Exception as exc:  # noqa: BLE001
+                result.status = "error"
+                result.error = str(exc)
+            finally:
+                await engine.dispose()
+                await session.commit()
+
+    import asyncio
+
+    asyncio.run(_run())

--- a/my_superset_fastapi/app/core/config.py
+++ b/my_superset_fastapi/app/core/config.py
@@ -1,0 +1,24 @@
+from functools import lru_cache
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+    APP_NAME: str = "My Superset FastAPI"
+    DEBUG: bool = False
+    SECRET_KEY: str = "change-this-key"  # noqa: S105
+    DATABASE_URL: str = "sqlite+aiosqlite:///./app.db"
+    CELERY_BROKER_URL: str = "redis://localhost:6379/0"
+    CELERY_RESULT_BACKEND: str = "redis://localhost:6379/1"
+    ALLOWED_ORIGINS: list[str] = []
+    RATE_LIMIT: str | None = "100/minute"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/my_superset_fastapi/app/core/db.py
+++ b/my_superset_fastapi/app/core/db.py
@@ -1,0 +1,18 @@
+from sqlalchemy.ext.asyncio import (
+    async_sessionmaker,
+    AsyncSession,
+    create_async_engine,
+)
+
+from .config import get_settings
+
+settings = get_settings()
+
+engine = create_async_engine(settings.DATABASE_URL, echo=settings.DEBUG)
+
+AsyncSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+
+async def get_db() -> AsyncSession:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/my_superset_fastapi/app/core/exceptions.py
+++ b/my_superset_fastapi/app/core/exceptions.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+
+async def http_error_handler(_: Request, exc: Exception) -> JSONResponse:
+    return JSONResponse({"detail": str(exc)}, status_code=500)
+
+
+async def validation_exception_handler(
+    _: Request, exc: RequestValidationError
+) -> JSONResponse:
+    return JSONResponse({"detail": exc.errors()}, status_code=422)
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    app.add_exception_handler(Exception, http_error_handler)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)

--- a/my_superset_fastapi/app/core/logging.py
+++ b/my_superset_fastapi/app/core/logging.py
@@ -1,0 +1,8 @@
+import logging
+
+
+def setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    )

--- a/my_superset_fastapi/app/models/__init__.py
+++ b/my_superset_fastapi/app/models/__init__.py
@@ -1,0 +1,21 @@
+from .base import Base
+from .chart import Chart
+from .dashboard import Dashboard
+from .dashboard_chart import DashboardChart
+from .database import Database
+from .dataset import Dataset
+from .dataset_column import DatasetColumn
+from .dataset_metric import DatasetMetric
+from .query_result import QueryResult
+
+__all__ = [
+    "Base",
+    "Database",
+    "Dataset",
+    "DatasetColumn",
+    "DatasetMetric",
+    "Chart",
+    "Dashboard",
+    "DashboardChart",
+    "QueryResult",
+]

--- a/my_superset_fastapi/app/models/base.py
+++ b/my_superset_fastapi/app/models/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/my_superset_fastapi/app/models/chart.py
+++ b/my_superset_fastapi/app/models/chart.py
@@ -1,0 +1,32 @@
+from enum import Enum as PyEnum
+
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, func, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from .base import Base
+from .dashboard_chart import DashboardChart
+
+
+class Chart(Base):
+    __tablename__ = "charts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    dataset_id = Column(Integer, ForeignKey("datasets.id"), nullable=False)
+
+    class ChartType(PyEnum):
+        PIE = "pie"
+        BAR = "bar"
+        TIME_SERIES = "time_series"
+        TABLE = "table"
+
+    chart_type = Column(Enum(ChartType), nullable=False, default=ChartType.TABLE)
+    config = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    dataset = relationship("Dataset", back_populates="charts")
+    dashboards = relationship(
+        "Dashboard",
+        secondary=DashboardChart,
+        back_populates="charts",
+    )

--- a/my_superset_fastapi/app/models/dashboard.py
+++ b/my_superset_fastapi/app/models/dashboard.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, DateTime, func, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from .base import Base
+from .dashboard_chart import DashboardChart
+
+
+class Dashboard(Base):
+    __tablename__ = "dashboards"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(255), nullable=False)
+    layout = Column(Text, nullable=True)
+    filters = Column(Text, nullable=True)
+    share_token = Column(String(255), nullable=True, unique=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    charts = relationship(
+        "Chart",
+        secondary=DashboardChart,
+        back_populates="dashboards",
+    )

--- a/my_superset_fastapi/app/models/dashboard_chart.py
+++ b/my_superset_fastapi/app/models/dashboard_chart.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, ForeignKey, Integer, Table
+
+from .base import Base
+
+DashboardChart = Table(
+    "dashboard_charts",
+    Base.metadata,
+    Column("dashboard_id", Integer, ForeignKey("dashboards.id"), primary_key=True),
+    Column("chart_id", Integer, ForeignKey("charts.id"), primary_key=True),
+)

--- a/my_superset_fastapi/app/models/database.py
+++ b/my_superset_fastapi/app/models/database.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, DateTime, func, Integer, String
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class Database(Base):
+    """Connection information for a database."""
+
+    __tablename__ = "databases"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False, unique=True)
+    sqlalchemy_uri = Column(String(1024), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    datasets = relationship("Dataset", back_populates="database")
+
+    # TODO: encrypt credentials or integrate with secrets manager

--- a/my_superset_fastapi/app/models/dataset.py
+++ b/my_superset_fastapi/app/models/dataset.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, DateTime, ForeignKey, func, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class Dataset(Base):
+    __tablename__ = "datasets"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False, unique=True)
+    database_id = Column(Integer, ForeignKey("databases.id"), nullable=True)
+    schema_name = Column(String(255), nullable=True)
+    table_name = Column(String(255), nullable=True)
+    sql = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    database = relationship("Database", back_populates="datasets")
+    charts = relationship("Chart", back_populates="dataset")
+    columns = relationship("DatasetColumn", back_populates="dataset")
+    metrics = relationship("DatasetMetric", back_populates="dataset")
+
+    # TODO: add tags/categories relationships

--- a/my_superset_fastapi/app/models/dataset_column.py
+++ b/my_superset_fastapi/app/models/dataset_column.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class DatasetColumn(Base):
+    """Model for dataset columns."""
+
+    __tablename__ = "dataset_columns"
+
+    id = Column(Integer, primary_key=True, index=True)
+    dataset_id = Column(Integer, ForeignKey("datasets.id", ondelete="CASCADE"))
+    name = Column(String(255), nullable=False)
+    type = Column(String(255), nullable=True)
+
+    dataset = relationship("Dataset", back_populates="columns")

--- a/my_superset_fastapi/app/models/dataset_metric.py
+++ b/my_superset_fastapi/app/models/dataset_metric.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class DatasetMetric(Base):
+    """Custom metrics defined for a dataset."""
+
+    __tablename__ = "dataset_metrics"
+
+    id = Column(Integer, primary_key=True, index=True)
+    dataset_id = Column(Integer, ForeignKey("datasets.id", ondelete="CASCADE"))
+    name = Column(String(255), nullable=False)
+    expression = Column(String(1024), nullable=False)
+
+    dataset = relationship("Dataset", back_populates="metrics")

--- a/my_superset_fastapi/app/models/query_result.py
+++ b/my_superset_fastapi/app/models/query_result.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, DateTime, ForeignKey, func, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class QueryResult(Base):
+    """Store SQL execution results."""
+
+    __tablename__ = "query_results"
+
+    id = Column(Integer, primary_key=True, index=True)
+    database_id = Column(Integer, ForeignKey("databases.id"))
+    sql = Column(Text, nullable=False)
+    status = Column(String(32), nullable=False, default="pending")
+    started_at = Column(DateTime(timezone=True), server_default=func.now())
+    finished_at = Column(DateTime(timezone=True), nullable=True)
+    rows = Column(Integer, nullable=True)
+    result = Column(Text, nullable=True)
+    error = Column(Text, nullable=True)
+
+    database = relationship("Database")

--- a/my_superset_fastapi/app/schemas/chart.py
+++ b/my_superset_fastapi/app/schemas/chart.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ChartBase(BaseModel):
+    name: str
+    dataset_id: int
+    chart_type: str | None = None
+    config: str | None = None
+
+
+class ChartCreate(ChartBase):
+    pass
+
+
+class ChartRead(ChartBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/my_superset_fastapi/app/schemas/dashboard.py
+++ b/my_superset_fastapi/app/schemas/dashboard.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class DashboardBase(BaseModel):
+    title: str
+    layout: str | None = None
+    filters: str | None = None
+
+
+class DashboardCreate(DashboardBase):
+    share_token: str | None = None
+
+
+class DashboardRead(DashboardBase):
+    id: int
+    share_token: str | None = None
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/my_superset_fastapi/app/schemas/database.py
+++ b/my_superset_fastapi/app/schemas/database.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class DatabaseBase(BaseModel):
+    name: str
+    sqlalchemy_uri: str
+
+
+class DatabaseCreate(DatabaseBase):
+    pass
+
+
+class DatabaseRead(DatabaseBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/my_superset_fastapi/app/schemas/dataset.py
+++ b/my_superset_fastapi/app/schemas/dataset.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class DatasetBase(BaseModel):
+    name: str
+    database_id: int | None = None
+    schema_name: str | None = None
+    table_name: str | None = None
+    sql: str | None = None
+
+
+class DatasetCreate(DatasetBase):
+    columns: list[str] | None = None  # TODO: replace with proper objects
+    metrics: list[str] | None = None
+
+
+class DatasetRead(DatasetBase):
+    id: int
+    created_at: datetime
+    columns: list[str] | None = None
+    metrics: list[str] | None = None
+
+    class Config:
+        orm_mode = True

--- a/my_superset_fastapi/app/schemas/query.py
+++ b/my_superset_fastapi/app/schemas/query.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class QueryCreate(BaseModel):
+    sql: str
+    database_id: int
+
+
+class QueryRead(QueryCreate):
+    id: int
+    status: str
+    result: str | None = None
+    error: str | None = None
+    rows: int | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
+    class Config:
+        orm_mode = True

--- a/my_superset_fastapi/app/services/__init__.py
+++ b/my_superset_fastapi/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for business logic."""

--- a/my_superset_fastapi/app/services/chart_service.py
+++ b/my_superset_fastapi/app/services/chart_service.py
@@ -1,0 +1,29 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chart import Chart
+from app.schemas.chart import ChartCreate
+
+
+class ChartService:
+    @staticmethod
+    async def create(db: AsyncSession, data: ChartCreate) -> Chart:
+        chart = Chart(
+            name=data.name,
+            dataset_id=data.dataset_id,
+            chart_type=data.chart_type,
+            config=data.config,
+        )
+        db.add(chart)
+        await db.commit()
+        await db.refresh(chart)
+        return chart
+
+    @staticmethod
+    async def list(db: AsyncSession) -> list[Chart]:
+        result = await db.execute(select(Chart))
+        return result.scalars().all()
+
+    @staticmethod
+    async def get(db: AsyncSession, chart_id: int) -> Chart | None:
+        return await db.get(Chart, chart_id)

--- a/my_superset_fastapi/app/services/dashboard_service.py
+++ b/my_superset_fastapi/app/services/dashboard_service.py
@@ -1,0 +1,29 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dashboard import Dashboard
+from app.schemas.dashboard import DashboardCreate
+
+
+class DashboardService:
+    @staticmethod
+    async def create(db: AsyncSession, data: DashboardCreate) -> Dashboard:
+        dashboard = Dashboard(
+            title=data.title,
+            layout=data.layout,
+            filters=data.filters,
+            share_token=data.share_token,
+        )
+        db.add(dashboard)
+        await db.commit()
+        await db.refresh(dashboard)
+        return dashboard
+
+    @staticmethod
+    async def list(db: AsyncSession) -> list[Dashboard]:
+        result = await db.execute(select(Dashboard))
+        return result.scalars().all()
+
+    @staticmethod
+    async def get(db: AsyncSession, dashboard_id: int) -> Dashboard | None:
+        return await db.get(Dashboard, dashboard_id)

--- a/my_superset_fastapi/app/services/database_service.py
+++ b/my_superset_fastapi/app/services/database_service.py
@@ -1,0 +1,41 @@
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from app.models.database import Database
+from app.schemas.database import DatabaseCreate
+
+
+class DatabaseService:
+    @staticmethod
+    async def create(db: AsyncSession, data: DatabaseCreate) -> Database:
+        database = Database(name=data.name, sqlalchemy_uri=data.sqlalchemy_uri)
+        db.add(database)
+        await db.commit()
+        await db.refresh(database)
+        return database
+
+    @staticmethod
+    async def test_connection(data: DatabaseCreate) -> None:
+        engine = create_async_engine(data.sqlalchemy_uri)
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+        finally:
+            await engine.dispose()
+
+    @staticmethod
+    async def introspect_schema(
+        db: AsyncSession, database_id: int
+    ) -> dict[str, list[str]]:
+        database = await db.get(Database, database_id)
+        if not database:
+            return {}
+        engine = create_async_engine(database.sqlalchemy_uri)
+        metadata = {}
+        try:
+            async with engine.connect() as conn:
+                result = await conn.run_sync(lambda c: c.dialect.get_table_names(c))
+                metadata["tables"] = result
+        finally:
+            await engine.dispose()
+        return metadata

--- a/my_superset_fastapi/app/services/dataset_service.py
+++ b/my_superset_fastapi/app/services/dataset_service.py
@@ -1,0 +1,36 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Dataset, DatasetColumn, DatasetMetric
+from app.schemas.dataset import DatasetCreate
+
+
+class DatasetService:
+    @staticmethod
+    async def create(db: AsyncSession, data: DatasetCreate) -> Dataset:
+        dataset = Dataset(
+            name=data.name,
+            database_id=data.database_id,
+            schema_name=data.schema_name,
+            table_name=data.table_name,
+            sql=data.sql,
+        )
+        db.add(dataset)
+        if data.columns:
+            for col in data.columns:
+                db.add(DatasetColumn(dataset=dataset, name=col))
+        if data.metrics:
+            for metric in data.metrics:
+                db.add(DatasetMetric(dataset=dataset, name=metric, expression=""))
+        await db.commit()
+        await db.refresh(dataset)
+        return dataset
+
+    @staticmethod
+    async def list(db: AsyncSession) -> list[Dataset]:
+        result = await db.execute(select(Dataset))
+        return result.scalars().all()
+
+    @staticmethod
+    async def get(db: AsyncSession, dataset_id: int) -> Dataset | None:
+        return await db.get(Dataset, dataset_id)

--- a/my_superset_fastapi/app/services/query_service.py
+++ b/my_superset_fastapi/app/services/query_service.py
@@ -1,0 +1,19 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.celery import celery_app
+from app.models.query_result import QueryResult
+
+
+class QueryService:
+    @staticmethod
+    async def submit_query(db: AsyncSession, sql: str, database_id: int) -> QueryResult:
+        result = QueryResult(database_id=database_id, sql=sql)
+        db.add(result)
+        await db.commit()
+        await db.refresh(result)
+        celery_app.send_task("execute_sql", args=[result.id])
+        return result
+
+    @staticmethod
+    async def get_result(db: AsyncSession, query_id: int) -> QueryResult | None:
+        return await db.get(QueryResult, query_id)

--- a/my_superset_fastapi/app/utils/__init__.py
+++ b/my_superset_fastapi/app/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Common utility functions."""

--- a/my_superset_fastapi/docker-compose.yml
+++ b/my_superset_fastapi/docker-compose.yml
@@ -1,0 +1,47 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: superset
+      POSTGRES_PASSWORD: superset
+      POSTGRES_DB: superset
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  api:
+    build: .
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    volumes:
+      - .:/code
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://superset:superset@db:5432/superset
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/1
+    depends_on:
+      - db
+      - redis
+  worker:
+    build: .
+    command: celery -A app.core.celery.celery_app worker --loglevel=info
+    volumes:
+      - .:/code
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://superset:superset@db:5432/superset
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/1
+    depends_on:
+      - db
+      - redis
+  frontend:
+    build:
+      context: ../my_superset_frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_API_URL=http://localhost:8000
+    depends_on:
+      - api

--- a/my_superset_fastapi/main.py
+++ b/my_superset_fastapi/main.py
@@ -1,0 +1,41 @@
+from app.api.v1 import api_router
+from app.core.config import get_settings
+from app.core.exceptions import register_exception_handlers
+from app.core.logging import setup_logging
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from slowapi import Limiter
+from slowapi.middleware import SlowAPIMiddleware
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+    setup_logging()
+    app = FastAPI(title=settings.APP_NAME)
+
+    if settings.ALLOWED_ORIGINS:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=settings.ALLOWED_ORIGINS,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+    if settings.RATE_LIMIT:
+        limiter = Limiter(
+            key_func=lambda request: request.client.host,
+            default_limits=[settings.RATE_LIMIT],
+        )
+        app.state.limiter = limiter
+        app.add_middleware(SlowAPIMiddleware)
+
+    register_exception_handlers(app)
+
+    app.include_router(api_router, prefix="/api/v1")
+    # TODO: enable authentication routes once configuration is complete
+
+    return app
+
+
+app = create_app()

--- a/my_superset_fastapi/requirements.txt
+++ b/my_superset_fastapi/requirements.txt
@@ -1,0 +1,13 @@
+fastapi
+uvicorn
+sqlalchemy[asyncio] >= 2.0
+asyncpg
+pydantic >= 2.0
+pydantic - settings
+alembic
+celery
+redis
+fastapi - users[sqlalchemy2]
+httpx
+slowapi
+aiosqlite

--- a/my_superset_fastapi/tests/test_basic.py
+++ b/my_superset_fastapi/tests/test_basic.py
@@ -1,0 +1,22 @@
+from app.core.db import engine
+from app.models.base import Base
+from fastapi.testclient import TestClient
+from main import create_app
+
+app = create_app()
+
+
+async def setup_database() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await setup_database()
+
+
+def test_health() -> None:
+    with TestClient(app) as client:
+        response = client.get("/api/v1/datasets")
+        assert response.status_code == 200

--- a/my_superset_frontend/.env.local.example
+++ b/my_superset_frontend/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/my_superset_frontend/Dockerfile
+++ b/my_superset_frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/my_superset_frontend/README.md
+++ b/my_superset_frontend/README.md
@@ -1,0 +1,31 @@
+# My Superset Frontend
+
+A minimal Next.js frontend that connects to the FastAPI backend.
+
+## Features
+
+- List datasets, charts, and dashboards
+- Submit SQL queries via SQL Lab page
+- Simple JWT login using FastAPI Users
+
+## Development
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Copy `.env.local.example` to `.env.local` and set `NEXT_PUBLIC_API_URL`
+3. Start the dev server
+   ```bash
+   npm run dev
+   ```
+
+The frontend expects the backend available at the URL specified in `NEXT_PUBLIC_API_URL` (default `http://localhost:8000`).
+
+### Docker
+
+A basic `Dockerfile` is provided. When using Docker Compose from the backend folder it will build the frontend service automatically.
+
+### Testing the API
+
+Use the pages under `/datasets`, `/charts`, `/dashboards`, and `/sql-lab` to interact with the backend. If you encounter CORS issues or a 401 error, check that the backend is running and the URL is correct.

--- a/my_superset_frontend/lib/api.ts
+++ b/my_superset_frontend/lib/api.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
+});
+
+api.interceptors.request.use(config => {
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+export default api;

--- a/my_superset_frontend/next-env.d.ts
+++ b/my_superset_frontend/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/my_superset_frontend/next.config.mjs
+++ b/my_superset_frontend/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'export',
+};
+
+export default nextConfig;

--- a/my_superset_frontend/package.json
+++ b/my_superset_frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "my_superset_frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "axios": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "@types/react": "latest",
+    "@types/node": "latest",
+    "@types/react-dom": "latest"
+  }
+}

--- a/my_superset_frontend/pages/_app.tsx
+++ b/my_superset_frontend/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from 'next/app';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/my_superset_frontend/pages/charts.tsx
+++ b/my_superset_frontend/pages/charts.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import api from '../lib/api';
+
+interface Chart {
+  id: number;
+  name: string;
+  chart_type: string;
+}
+
+export default function Charts() {
+  const [charts, setCharts] = useState<Chart[]>([]);
+
+  useEffect(() => {
+    api.get('/api/v1/charts').then(r => setCharts(r.data.items || []));
+  }, []);
+
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Charts</h1>
+      <ul>
+        {charts.map(ch => (
+          <li key={ch.id}>{ch.name} - {ch.chart_type}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/my_superset_frontend/pages/dashboards.tsx
+++ b/my_superset_frontend/pages/dashboards.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import api from '../lib/api';
+
+interface Dashboard {
+  id: number;
+  title: string;
+  layout: string;
+}
+
+export default function Dashboards() {
+  const [dashboards, setDashboards] = useState<Dashboard[]>([]);
+
+  useEffect(() => {
+    api.get('/api/v1/dashboards').then(r => setDashboards(r.data.items || []));
+  }, []);
+
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Dashboards</h1>
+      <ul>
+        {dashboards.map(db => (
+          <li key={db.id}>{db.title}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/my_superset_frontend/pages/datasets.tsx
+++ b/my_superset_frontend/pages/datasets.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import api from '../lib/api';
+
+interface Dataset {
+  id: number;
+  name: string;
+  database: string;
+  is_virtual: boolean;
+}
+
+export default function Datasets() {
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+
+  useEffect(() => {
+    api.get('/api/v1/datasets').then(r => setDatasets(r.data.items || []));
+  }, []);
+
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Datasets</h1>
+      <ul>
+        {datasets.map(ds => (
+          <li key={ds.id}>{ds.name} - {ds.database} - {ds.is_virtual ? 'virtual' : 'physical'}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/my_superset_frontend/pages/index.tsx
+++ b/my_superset_frontend/pages/index.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>My Superset Frontend</h1>
+      <ul>
+        <li><Link href="/datasets">Datasets</Link></li>
+        <li><Link href="/charts">Charts</Link></li>
+        <li><Link href="/dashboards">Dashboards</Link></li>
+        <li><Link href="/sql-lab">SQL Lab</Link></li>
+      </ul>
+    </main>
+  );
+}

--- a/my_superset_frontend/pages/login.tsx
+++ b/my_superset_frontend/pages/login.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import api from '../lib/api';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const { data } = await api.post('/auth/jwt/login', new URLSearchParams({
+        username: email,
+        password,
+      }));
+      localStorage.setItem('token', data.access_token);
+      router.push('/');
+    } catch (err) {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Login</h1>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <form onSubmit={submit}>
+        <div>
+          <input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        </div>
+        <div>
+          <input placeholder="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+        </div>
+        <button type="submit">Login</button>
+      </form>
+    </main>
+  );
+}

--- a/my_superset_frontend/pages/sql-lab.tsx
+++ b/my_superset_frontend/pages/sql-lab.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import api from '../lib/api';
+
+export default function SqlLab() {
+  const [sql, setSql] = useState('');
+  const [result, setResult] = useState<any>(null);
+  const [jobId, setJobId] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { data } = await api.post('/api/v1/queries', { sql });
+    setJobId(data.id);
+    poll(data.id);
+  };
+
+  const poll = async (id: string) => {
+    const interval = setInterval(async () => {
+      const { data } = await api.get(`/api/v1/queries/${id}`);
+      if (data.status === 'finished') {
+        clearInterval(interval);
+        setResult(data.result);
+      }
+    }, 1000);
+  };
+
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>SQL Lab</h1>
+      <form onSubmit={submit}>
+        <textarea rows={5} cols={60} value={sql} onChange={e => setSql(e.target.value)} />
+        <div>
+          <button type="submit">Run</button>
+        </div>
+      </form>
+      {jobId && !result && <p>Running job {jobId}...</p>}
+      {result && (
+        <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(result, null, 2)}</pre>
+      )}
+    </main>
+  );
+}

--- a/my_superset_frontend/tsconfig.json
+++ b/my_superset_frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold `my_superset_fastapi` project with FastAPI
- add models, services, schemas and API routers
- configure SQLAlchemy async engine and Celery
- provide sample test
- extend backend with auth setup, dataset metadata and query engine
- add simple Next.js frontend with dataset, chart, dashboard, and SQL Lab views
- update docker-compose to run API, worker and frontend

## Testing
- `pre-commit run --files my_superset_fastapi/Dockerfile my_superset_fastapi/README.md my_superset_fastapi/docker-compose.yml my_superset_frontend/.env.local.example my_superset_frontend/Dockerfile my_superset_frontend/README.md my_superset_frontend/lib/api.ts my_superset_frontend/next-env.d.ts my_superset_frontend/next.config.mjs my_superset_frontend/package.json my_superset_frontend/pages/_app.tsx my_superset_frontend/pages/charts.tsx my_superset_frontend/pages/dashboards.tsx my_superset_frontend/pages/datasets.tsx my_superset_frontend/pages/index.tsx my_superset_frontend/pages/login.tsx my_superset_frontend/pages/sql-lab.tsx my_superset_frontend/tsconfig.json`
- `pytest my_superset_fastapi/tests/test_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_6878e0dabf888322a306d8985a5944ca